### PR TITLE
Fix incorrect device listing

### DIFF
--- a/keylogger.go
+++ b/keylogger.go
@@ -22,7 +22,7 @@ func NewDevices() ([]*InputDevice, error) {
 	for i := 0; i < MAX_FILES; i++ {
 		buff, err := ioutil.ReadFile(fmt.Sprintf(INPUTS, i))
 		if err != nil {
-			break
+			continue
 		}
 		ret = append(ret, newInputDeviceReader(buff, i))
 	}


### PR DESCRIPTION
If the device list is not consecutive, the app
would not list all the devices correctly