### PR TITLE
Made root permission check work for setuid bit (EUID)

### DIFF
--- a/keylogger.go
+++ b/keylogger.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"strings"
+	"syscall"
 )
 
 func NewDevices() ([]*InputDevice, error) {
@@ -31,11 +31,7 @@ func NewDevices() ([]*InputDevice, error) {
 }
 
 func checkRoot() error {
-	u, err := user.Current()
-	if err != nil {
-		return err
-	}
-	if u.Uid != "0" {
+	if syscall.Getuid() != 0 && syscall.Geteuid() != 0 {
 		return fmt.Errorf("Cannot read device files. Are you running as root?")
 	}
 	return nil


### PR DESCRIPTION
Hi

Thanks for this code!

I wrote a simple logger program using your library, but i wanted it to be run with the setuid bit set.

Currently, the checkRoot() function only checks for a UID of 0 (root). This means that the check will fail when the binary is run as setuid root. i updated the checkRoot() function to handle the case when the EUID (effective UID) is 0 as well as when the UID is 0.

I think it's a small improvement so i thought you might want to add it.

Example below using this code:

```golang
package main

import (
	"github.com/MarinX/keylogger"
)

func main() {
	_, err := keylogger.NewDevices()
	if err != nil {
		println(err.Error())
	}
}

```

Behaivour before this PR:

```
$ go build main.go
$ sudo chown root main
$ sudo chmod u+s main
$ ./main
Cannot read device files. Are you running as root?
$
```

Behaivour after this PR:

```
$ go build main.go
$ sudo chown root main
$ sudo chmod u+s main
$ ./main
$
```
