### PR TITLE
Fix bug where we get mouse as an keyboard device

### DIFF
--- a/keylogger.go
+++ b/keylogger.go
@@ -41,6 +41,14 @@ func FindKeyboardDevice() string {
 		if err != nil {
 			logrus.Error(err)
 		}
+
+		// check if mouse is contained in the input event
+		// if that is the case just skip.
+		// We do this check as it seems that some mouses like the logitech MX mouse is also recognized as a mouse/keyboard
+		if strings.Contains(strings.ToLower(string(buff)), "mouse") {
+			continue
+		}
+
 		if strings.Contains(strings.ToLower(string(buff)), "keyboard") {
 			return fmt.Sprintf(resolved, i)
 		}


### PR DESCRIPTION
I had an issue where my mouse was detected as a keyboard device. This was the name of my input device in `/sys/class/input/event3/device/name` -> "USB OPTICAL MOUSE  Keyboard".

So I updated the code to check if the mouse keyword is present in the name and if it just skips the input.